### PR TITLE
rust/cicd: separate github action workflow

### DIFF
--- a/.github/workflows/build-rs.yml
+++ b/.github/workflows/build-rs.yml
@@ -3,9 +3,12 @@ name: build-rs
 on:
   push:
     branches: [ "main" ]
+    paths:
+        - 'rust/**'
   pull_request:
     branches: [ "*" ]
-
+    paths:
+        - 'rust/**'
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
separate the rust workflow from others (java, ...)