### PR TITLE
feat/java/examples: add snippets as javadoc code (JDK17 compatibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ data-series functions support for data-series and time-series.
 [![build](https://github.com/cboudereau/dataseries/workflows/build-java/badge.svg?branch=main&event=push)](https://github.com/cboudereau/dataseries/actions/workflows/build-java.yml?query=event%3Apush+branch%3Amain)
 [![codecov](https://codecov.io/gh/cboudereau/dataseries/branch/main/graph/badge.svg?token=UFSTKQG9FY&flag=java)](https://app.codecov.io/gh/cboudereau/dataseries/tree/main/java)
 [![maven central](https://img.shields.io/maven-central/v/io.github.cboudereau.dataseries/dataseries.svg)](https://search.maven.org/artifact/io.github.cboudereau.dataseries/dataseries/)
+[![javadoc](https://www.javadoc.io/badge/io.github.cboudereau.dataseries/dataseries.svg)](https://www.javadoc.io/doc/io.github.cboudereau.dataseries/dataseries)
 
 ## functions
 

--- a/java/README.md
+++ b/java/README.md
@@ -29,18 +29,287 @@ Expected: |-----|-----|----|------|------|-
 
 ### examples
 
-#### (TODO) simple
+#### simple
 A simple example of ```union``` between 2 timeseries
 
-#### (TODO) intersection
+```java
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class SimpleTest {
+    @Test
+    public void simple() {
+        final var s1 = List.of(Series.datapoint(3, 50));
+        final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));
+
+        final var actual = Series.union(s1, s2, x -> x).stream().toArray();
+
+        final var expected = List.of(
+                Series.datapoint(3, UnionResult.leftOnly(50)),
+                Series.datapoint(4, UnionResult.both(50, 100)),
+                Series.datapoint(7, UnionResult.both(50, 110))).toArray();
+
+        assertArrayEquals(expected, actual);
+    }
+}
+```
+
+#### intersection
 An intersection implementation using the ```union``` function.
 
-### (TODO) eventual consistency and conflict resolution
+```java
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class IntersectionTest {
+    @Test
+    public void intersection() {
+        final var s1 = List.of(Series.datapoint(3, 50));
+        final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));
+
+        final var actual = Series.union(s1, s2, IntersectionTest::toTuple).stream().filter(x -> x.data().isPresent())
+                .map(x -> Series.datapoint(x.point(), x.data().get())).toArray();
+
+        final var expected = List.of(
+                Series.datapoint(4, new Tuple<>(50, 100)),
+                Series.datapoint(7, new Tuple<>(50, 110))).toArray();
+
+        assertArrayEquals(expected, actual);
+    }
+
+    private static record Tuple<L, R>(L fst, R snd) {
+    }
+
+    private static <L, R> Optional<Tuple<L, R>> toTuple(UnionResult<L, R> unionResult) {
+        switch (unionResult) {
+            case UnionResult.LeftOnly<L, R> x -> {
+                return Optional.empty();
+            }
+            case UnionResult.RightOnly<L, R> x -> {
+                return Optional.empty();
+            }
+
+            case UnionResult.Both<L, R> both -> {
+                return Optional.of(new Tuple<L, R>(both.left(), both.right()));
+            }
+        }
+    }
+}
+```
+
+### eventual consistency and conflict resolution
 The ```crdt``` example provides an example of the conflict-free replicated data type resolution based on data-series ```union```.
 
 The ```VersionedValue``` defines the version (here a timestamp) to solve the conflict by taking the maximum version. The maximum is defined through the ```Comparable``` interface and used inside the given function used by ```union```.
 
 The below example uses TimestampMicros to version the data and solve conflict by taking the highest version of a value.
+
 ```java
-// TODO
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.DataPoint;
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class CrdtTest {
+    @Test
+    public void resolveConflictsTest() {
+        final var actual = Series.union(List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10))),
+                List.of(
+                        datapoint(2, date(2023, 1, 4), 100),
+                        end(date(2023, 1, 5)),
+                        datapoint(2, date(2023, 1, 7), 110),
+                        end(date(2023, 1, 9))),
+                CrdtTest::resolveConflicts);
+
+        final var expected = List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                datapoint(2, date(2023, 1, 4), 100),
+                datapoint(1, date(2023, 1, 5), 50),
+                datapoint(2, date(2023, 1, 7), 110),
+                datapoint(1, date(2023, 1, 9), 50),
+                end(date(2023, 1, 10)));
+
+        assertArrayEquals(expected.toArray(), actual.stream().toArray());
+    }
+
+    @Test
+    public void noConflictTest() {
+        final var actual = Series.union(List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10))),
+                List.of(
+                        datapoint(2, date(2023, 1, 15), 100),
+                        end(date(2023, 1, 20))
+
+                ), CrdtTest::resolveConflicts);
+
+        final var expected = List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10)),
+                datapoint(2, date(2023, 1, 15), 100),
+                end(date(2023, 1, 20)));
+        assertArrayEquals(expected.toArray(), actual.stream().toArray());
+    }
+
+    /**
+     * Optional from java.util does not provide any Comparable<Optional<T>>
+     * implementation like other languages (rust with traits).
+     * 
+     * This Algebraic data type provides this implementation of a conventional
+     * option.
+     */
+    private static sealed interface Option<T extends Comparable<T>> extends Comparable<Option<T>>
+            permits Option.None, Option.Some {
+        default int compareTo(final Option<T> o) {
+            switch (this) {
+                case final None<T> n1 -> {
+                    switch (o) {
+                        case final None<T> n2 -> {
+                            return 0;
+                        }
+                        case final Some<T> s -> {
+                            return -1;
+                        }
+                    }
+                }
+                case final Some<T> s1 -> {
+                    switch (o) {
+                        case None<T> n -> {
+                            return 1;
+                        }
+                        case Some<T> s2 -> {
+                            return s1.value.compareTo(s2.value);
+                        }
+                    }
+                }
+            }
+        }
+
+        static record None<T extends Comparable<T>>() implements Option<T> {
+        }
+
+        static record Some<T extends Comparable<T>>(T value) implements Option<T> {
+
+        }
+
+        private static <T extends Comparable<T>> Option<T> none() {
+            return new None<>();
+        }
+
+        private static <T extends Comparable<T>> Option<T> some(final T value) {
+            return new Some<>(value);
+        }
+    }
+
+    private static record VersionedValue<V extends Comparable<V>, T extends Comparable<T>>(V version, T value)
+            implements Comparable<VersionedValue<V, T>> {
+        @Override
+        public int compareTo(final VersionedValue<V, T> o) {
+            var vc = this.version.compareTo(o.version);
+
+            if (vc < 0) {
+                return -1;
+            }
+
+            if (vc > 0) {
+                return 1;
+            }
+
+            return this.value.compareTo(o.value);
+        }
+    }
+
+    private static record Date(Integer year, Integer month, Integer day) implements Comparable<Date> {
+
+        @Override
+        public int compareTo(final Date o) {
+            if (this.year > o.year) {
+                return 1;
+            }
+
+            if (this.year < o.year) {
+                return -1;
+            }
+
+            if (this.month > o.month) {
+                return 1;
+            }
+
+            if (this.month < o.month) {
+                return -1;
+            }
+
+            if (this.day > o.day) {
+                return 1;
+            }
+
+            if (this.day < o.day) {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+
+    private static final Date date(final Integer year, final Integer month, final Integer day) {
+        return new Date(year, month, day);
+    }
+
+    private static final <T extends Comparable<T>> DataPoint<Date, Option<VersionedValue<Integer, T>>> datapoint(
+            final Integer timestampMicros, final Date date, final T data) {
+        return Series.datapoint(date, Option.some(new VersionedValue<>(timestampMicros, data)));
+    }
+
+    /// Interval can be encoded by using 2 Datapoints with a [`None`] last datapoint
+    /// value to mark the end of each interval
+    private static final <T extends Comparable<T>> DataPoint<Date, Option<VersionedValue<Integer, T>>> end(
+            final Date date) {
+        return Series.datapoint(date, Option.none());
+    }
+
+    /**
+     * Solves conflict by taking always the maximum version
+     */
+    private static final <T extends Comparable<T>> T resolveConflicts(final UnionResult<T, T> unionResult) {
+        switch (unionResult) {
+            case final UnionResult.LeftOnly<T, T> l -> {
+                return l.left();
+            }
+            case final UnionResult.RightOnly<T, T> r -> {
+                return r.right();
+            }
+            case final UnionResult.Both<T, T> b -> {
+                if (b.right().compareTo(b.left()) > 0) {
+                    return b.right();
+                }
+
+                return b.left();
+            }
+        }
+    }
+}
 ```

--- a/java/README.md
+++ b/java/README.md
@@ -4,6 +4,7 @@
 [![build](https://github.com/cboudereau/dataseries/workflows/build-java/badge.svg?branch=main&event=push)](https://github.com/cboudereau/dataseries/actions/workflows/build-java.yml?query=event%3Apush+branch%3Amain)
 [![codecov](https://codecov.io/gh/cboudereau/dataseries/branch/main/graph/badge.svg?token=UFSTKQG9FY&flag=java)](https://app.codecov.io/gh/cboudereau/dataseries/tree/main/java)
 [![maven central](https://img.shields.io/maven-central/v/io.github.cboudereau.dataseries/dataseries.svg)](https://search.maven.org/artifact/io.github.cboudereau.dataseries/dataseries/)
+[![javadoc](https://www.javadoc.io/badge/io.github.cboudereau.dataseries/dataseries.svg)](https://www.javadoc.io/doc/io.github.cboudereau.dataseries/dataseries)
 
 data-series functions support for data-series and time-series.
 

--- a/java/SIDENOTES.md
+++ b/java/SIDENOTES.md
@@ -1,0 +1,8 @@
+# side notes
+
+## java doc and snippet (aka examples in rust)
+
+They are not exactly the same:
+- How to run it ?
+
+https://docs.oracle.com/en/java/javase/18/code-snippet/index.html#external-snippets

--- a/java/src/main/java/io/github/cboudereau/dataseries/DataPoint.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/DataPoint.java
@@ -3,10 +3,10 @@ package io.github.cboudereau.dataseries;
 /**
  * Data point record to store data at any given point.
  * 
- * @param <P> the point type
- * @param <T> the data type
+ * @param <P>   the point type
+ * @param <T>   the data type
  * @param point the point value
- * @param data the data value
+ * @param data  the data value
  */
 public record DataPoint<P, T>(P point, T data) {
 

--- a/java/src/main/java/io/github/cboudereau/dataseries/IterableSeries.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/IterableSeries.java
@@ -4,7 +4,8 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * IterableSeries wrap DataPoint and have a default useful method to use with the java stream api
+ * IterableSeries wrap DataPoint and have a default useful method to use with
+ * the java stream api
  * 
  * @param <P> the point type
  * @param <T> the data type
@@ -12,6 +13,7 @@ import java.util.stream.StreamSupport;
 public interface IterableSeries<P, T> extends Iterable<DataPoint<P, T>> {
     /**
      * Convert to a conventional stream
+     * 
      * @return a datapoint stream
      */
     public default Stream<DataPoint<P, T>> stream() {

--- a/java/src/main/java/io/github/cboudereau/dataseries/Merge.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/Merge.java
@@ -27,7 +27,7 @@ final class Merge<P, T> implements Iterator<DataPoint<P, T>> {
 
     private void pullEntry() {
         while (this.series.hasNext()) {
-            var next = this.series.next();
+            final var next = this.series.next();
 
             if (this.current.isEmpty()) {
                 this.current = Optional.of(next);
@@ -47,8 +47,8 @@ final class Merge<P, T> implements Iterator<DataPoint<P, T>> {
             this.entry = this.current;
             this.current = Optional.empty();
             return;
-        } 
-            
+        }
+
         this.hasNext = false;
         this.entry = Optional.empty();
         return;

--- a/java/src/main/java/io/github/cboudereau/dataseries/Series.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/Series.java
@@ -6,31 +6,33 @@ import java.util.function.Function;
  * The entrypoint of the api
  */
 public class Series {
-    private Series () {
+    private Series() {
 
     }
-    
+
     /**
      * a helper function to create a datapoint
-     * @param <P> the point type
-     * @param <T> the data type
+     * 
+     * @param <P>   the point type
+     * @param <T>   the data type
      * @param point the point
-     * @param data the data
+     * @param data  the data
      * @return a datapoint
      */
-    public static final <P, T> DataPoint<P, T> datapoint(final P point, final T data) {
+    public static final <P extends Comparable<P>, T> DataPoint<P, T> datapoint(final P point, final T data) {
         return new DataPoint<>(point, data);
     }
 
     /**
      * union 2 series and combine union result with the given function
-     * @param <P> the point type should be common for left and right series
-     * @param <L> the left type
-     * @param <R> the right type
-     * @param <T> the return of the applied function to union result
-     * @param left the left serie
+     * 
+     * @param <P>   the point type should be common for left and right series
+     * @param <L>   the left type
+     * @param <R>   the right type
+     * @param <T>   the return of the applied function to union result
+     * @param left  the left serie
      * @param right the right serie
-     * @param f the function applied to convert union result to T type
+     * @param f     the function applied to convert union result to T type
      * @return a iterable series
      */
     public static final <P extends Comparable<P>, L, R, T> IterableSeries<P, T> union(
@@ -41,10 +43,12 @@ public class Series {
 
     /**
      * merge a serie to be more compact when contigous events have the same data
-     * @param <P> the point type
-     * @param <T> the data type
+     * 
+     * @param <P>    the point type
+     * @param <T>    the data type
      * @param series the series to merge
-     * @return a merged series which have no more duplicated events for the same data
+     * @return a merged series which have no more duplicated events for the same
+     *         data
      */
     public static final <P, T> IterableSeries<P, T> merge(
             final Iterable<DataPoint<P, T>> series) {

--- a/java/src/main/java/io/github/cboudereau/dataseries/Series.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/Series.java
@@ -3,7 +3,298 @@ package io.github.cboudereau.dataseries;
 import java.util.function.Function;
 
 /**
- * The entrypoint of the api
+ * The entrypoint of the api, here is a simple usage of the union dataseries :
+ * 
+ * <code>
+ * <br/>
+ * <br/>
+ * package io.github.cboudereau.dataseries.snippets;<br/>
+ * <br/>
+ * import static org.junit.jupiter.api.Assertions.assertArrayEquals;<br/>
+ * <br/>
+ * import java.util.List;<br/>
+ * import org.junit.jupiter.api.Test;<br/>
+ * <br/>
+ * import io.github.cboudereau.dataseries.Series;<br/>
+ * import io.github.cboudereau.dataseries.UnionResult;<br/>
+ * <br/>
+ * public class SimpleTest {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#64;Test<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;public void simple() {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var s1 = List.of(Series.datapoint(3, 50));<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var actual = Series.union(s1, s2, x -> x).stream().toArray();<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var expected = List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series.datapoint(3, UnionResult.leftOnly(50)),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series.datapoint(4, UnionResult.both(50, 100)),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series.datapoint(7, UnionResult.both(50, 110))).toArray();<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertArrayEquals(expected, actual);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * }<br/>
+ * </code>
+ * <br/>
+ * Convert an Union to an Intersection example :
+ * snippets.IntersectionTest
+ * <code>
+ * <br/>
+ * <br/>
+ * package io.github.cboudereau.dataseries.snippets;<br/>
+ * <br/>
+ * import static org.junit.jupiter.api.Assertions.assertArrayEquals;<br/>
+ * import java.util.List;<br/>
+ * import java.util.Optional;<br/>
+ * <br/>
+ * import org.junit.jupiter.api.Test;<br/>
+ * <br/>
+ * import io.github.cboudereau.dataseries.Series;<br/>
+ * import io.github.cboudereau.dataseries.UnionResult;<br/>
+ * <br/>
+ * public class IntersectionTest {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#64;Test<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;public void intersection() {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var s1 = List.of(Series.datapoint(3, 50));<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var actual = Series.union(s1, s2, IntersectionTest::toTuple).stream().filter(x -&#62; x.data().isPresent())<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;.map(x -&#62; Series.datapoint(x.point(), x.data().get())).toArray();<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var expected = List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series.datapoint(4, new Tuple&#60;&#62;(50, 100)),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series.datapoint(7, new Tuple&#60;&#62;(50, 110))).toArray();<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertArrayEquals(expected, actual);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static record Tuple&#60;L, R&#62;(L fst, R snd) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static &#60;L, R&#62; Optional&#60;Tuple&#60;L, R&#62;&#62; toTuple(UnionResult&#60;L, R&#62; unionResult) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switch (unionResult) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case UnionResult.LeftOnly&#60;L, R&#62; x -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return Optional.empty();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case UnionResult.RightOnly&#60;L, R&#62; x -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return Optional.empty();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case UnionResult.Both&#60;L, R&#62; both -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return Optional.of(new Tuple&#60;L, R&#62;(both.left(), both.right()));<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * }
+ * <br/>
+ * </code>
+ * <br/>
+ * 
+ * And a more complex example using crdt strategy to merge conflicts between 2
+ * dataseries by using union
+ * 
+ * 
+ *
+ * <code>
+ * <br/>
+ * <br/>
+ * package io.github.cboudereau.dataseries.snippets;<br/>
+ * <br/>
+ * import static org.junit.jupiter.api.Assertions.assertArrayEquals;<br/>
+ * <br/>
+ * import java.util.List;<br/>
+ * <br/>
+ * import org.junit.jupiter.api.Test;<br/>
+ * <br/>
+ * import io.github.cboudereau.dataseries.DataPoint;<br/>
+ * import io.github.cboudereau.dataseries.Series;<br/>
+ * import io.github.cboudereau.dataseries.UnionResult;<br/>
+ * <br/>
+ * public class CrdtTest {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#64;Test<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;public void resolveConflictsTest() {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var actual = Series.union(List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 3), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 10))),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 4), 100),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 5)),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 7), 110),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 9))),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;CrdtTest::resolveConflicts);<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var expected = List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 3), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 4), 100),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 5), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 7), 110),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 9), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 10)));<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertArrayEquals(expected.toArray(), actual.stream().toArray());<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#64;Test<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;public void noConflictTest() {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var actual = Series.union(List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 3), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 10))),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 15), 100),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 20))<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;), CrdtTest::resolveConflicts);<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final var expected = List.of(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(1, date(2023, 1, 3), 50),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 10)),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;datapoint(2, date(2023, 1, 15), 100),<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end(date(2023, 1, 20)));<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;assertArrayEquals(expected.toArray(), actual.stream().toArray());<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#47;**<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * Optional from java.util does not provide any Comparable&#60;Optional&#60;T&#62;&#62;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * implementation like other languages (rust with traits).<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * This Algebraic data type provides this implementation of a conventional<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * option.<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; *&#47;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static sealed interface Option&#60;T extends Comparable&#60;T&#62;&#62; extends Comparable&#60;Option&#60;T&#62;&#62;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;permits Option.None, Option.Some {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default int compareTo(final Option&#60;T&#62; o) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switch (this) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final None&#60;T&#62; n1 -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switch (o) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final None&#60;T&#62; n2 -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 0;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final Some&#60;T&#62; s -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return -1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final Some&#60;T&#62; s1 -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switch (o) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case None&#60;T&#62; n -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case Some&#60;T&#62; s2 -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return s1.value.compareTo(s2.value);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static record None&#60;T extends Comparable&#60;T&#62;&#62;() implements Option&#60;T&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static record Some&#60;T extends Comparable&#60;T&#62;&#62;(T value) implements Option&#60;T&#62; {<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;private static &#60;T extends Comparable&#60;T&#62;&#62; Option&#60;T&#62; none() {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return new None&#60;&#62;();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;private static &#60;T extends Comparable&#60;T&#62;&#62; Option&#60;T&#62; some(final T value) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return new Some&#60;&#62;(value);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static record VersionedValue&#60;V extends Comparable&#60;V&#62;, T extends Comparable&#60;T&#62;&#62;(V version, T value)<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;implements Comparable&#60;VersionedValue&#60;V, T&#62;&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#64;Override<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;public int compareTo(final VersionedValue&#60;V, T&#62; o) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;var vc = this.version.compareTo(o.version);<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (vc &#60; 0) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return -1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (vc &#62; 0) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return this.value.compareTo(o.value);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static record Date(Integer year, Integer month, Integer day) implements Comparable&#60;Date&#62; {<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&#64;Override<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;public int compareTo(final Date o) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.year &#62; o.year) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.year &#60; o.year) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return -1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.month &#62; o.month) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.month &#60; o.month) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return -1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.day &#62; o.day) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (this.day &#60; o.day) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return -1;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return 0;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static final Date date(final Integer year, final Integer month, final Integer day) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return new Date(year, month, day);<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static final &#60;T extends Comparable&#60;T&#62;&#62; DataPoint&#60;Date, Option&#60;VersionedValue&#60;Integer, T&#62;&#62;&#62; datapoint(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final Integer timestampMicros, final Date date, final T data) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return Series.datapoint(date, Option.some(new VersionedValue&#60;&#62;(timestampMicros, data)));<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;/// Interval can be encoded by using 2 Datapoints with a [`None`] last datapoint<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;/// value to mark the end of each interval<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static final &#60;T extends Comparable&#60;T&#62;&#62; DataPoint&#60;Date, Option&#60;VersionedValue&#60;Integer, T&#62;&#62;&#62; end(<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;final Date date) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return Series.datapoint(date, Option.none());<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&#47;**<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; * Solves conflict by taking always the maximum version<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp; *&#47;<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;private static final &#60;T extends Comparable&#60;T&#62;&#62; T resolveConflicts(final UnionResult&#60;T, T&#62; unionResult) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;switch (unionResult) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final UnionResult.LeftOnly&#60;T, T&#62; l -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return l.left();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final UnionResult.RightOnly&#60;T, T&#62; r -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return r.right();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;case final UnionResult.Both&#60;T, T&#62; b -&#62; {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if (b.right().compareTo(b.left()) &#62; 0) {<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return b.right();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * <br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return b.left();<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * &nbsp;&nbsp;&nbsp;&nbsp;}<br/>
+ * }<br/>
+ * <br/>
+ * </code>
+ * <br/>
+ * 
+ * 
  */
 public class Series {
     private Series() {

--- a/java/src/main/java/io/github/cboudereau/dataseries/UnionResult.java
+++ b/java/src/main/java/io/github/cboudereau/dataseries/UnionResult.java
@@ -49,7 +49,7 @@ public sealed interface UnionResult<L, R> permits UnionResult.LeftOnly, UnionRes
      * @return A left only union result when there is no right data for the given
      *         point
      */
-    public static <L, R> UnionResult.LeftOnly<L, R> leftOnly(L left) {
+    public static <L, R> UnionResult.LeftOnly<L, R> leftOnly(final L left) {
         return new UnionResult.LeftOnly<L, R>(left);
     }
 
@@ -62,7 +62,7 @@ public sealed interface UnionResult<L, R> permits UnionResult.LeftOnly, UnionRes
      * @return A right only union result when there is no left data for the given
      *         point
      */
-    public static <L, R> UnionResult.RightOnly<L, R> rightOnly(R right) {
+    public static <L, R> UnionResult.RightOnly<L, R> rightOnly(final R right) {
         return new UnionResult.RightOnly<L, R>(right);
     }
 
@@ -75,7 +75,7 @@ public sealed interface UnionResult<L, R> permits UnionResult.LeftOnly, UnionRes
      * @param right the right data
      * @return A union of both (left and right)
      */
-    public static <L, R> UnionResult.Both<L, R> both(L left, R right) {
+    public static <L, R> UnionResult.Both<L, R> both(final L left, final R right) {
         return new UnionResult.Both<L, R>(left, right);
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/CursorIteratorTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/CursorIteratorTest.java
@@ -17,16 +17,16 @@ import io.github.cboudereau.dataseries.Union.Cursor;
 public class CursorIteratorTest {
     @Test
     public void emptyTest() {
-        List<Integer> empty = Collections.emptyList();
-        var actual = new CursorIterator<Integer>(empty.iterator());
+        final List<Integer> empty = Collections.emptyList();
+        final var actual = new CursorIterator<Integer>(empty.iterator());
         assertFalse(actual.hasNext());
         assertThrows(NoSuchElementException.class, () -> actual.next());
     }
 
     @Test
     public void singleCursorTest() {
-        List<Integer> empty = List.of(1);
-        var actual = new CursorIterator<Integer>(empty.iterator());
+        final List<Integer> empty = List.of(1);
+        final var actual = new CursorIterator<Integer>(empty.iterator());
         assertTrue(actual.hasNext());
         assertTrue(actual.hasNext());
         assertEquals(Union.Cursor.single(1), actual.next());
@@ -36,8 +36,8 @@ public class CursorIteratorTest {
 
     @Test
     public void simplePairCursorTest() {
-        List<Integer> empty = List.of(1, 2);
-        var actual = new CursorIterator<Integer>(empty.iterator());
+        final List<Integer> empty = List.of(1, 2);
+        final var actual = new CursorIterator<Integer>(empty.iterator());
         assertTrue(actual.hasNext());
         assertTrue(actual.hasNext());
 
@@ -54,8 +54,8 @@ public class CursorIteratorTest {
 
     @Test
     public void cursorPairTest() {
-        List<Integer> empty = List.of(1, 2, 3, 4, 5);
-        var actual = new CursorIterator<Integer>(empty.iterator());
+        final List<Integer> empty = List.of(1, 2, 3, 4, 5);
+        final var actual = new CursorIterator<Integer>(empty.iterator());
         assertTrue(actual.hasNext());
         assertTrue(actual.hasNext());
 

--- a/java/src/test/java/io/github/cboudereau/dataseries/DataPointTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/DataPointTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 public class DataPointTest {
     @Test
     public void datapointTest() {
-        var x = Series.datapoint(1, "hello");
-        var y = Series.datapoint(1, "hello");
+        final var x = Series.datapoint(1, "hello");
+        final var y = Series.datapoint(1, "hello");
         assertEquals(x, y);
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/MergeTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/MergeTest.java
@@ -14,46 +14,47 @@ public class MergeTest {
 
     @Test
     public void PullMergeWithEmptyValueTest() {
-        List<DataPoint<Integer, String>> x = List.of();
-        var iterator = Series.merge(x).iterator();
+        final List<DataPoint<Integer, String>> x = List.of();
+        final var iterator = Series.merge(x).iterator();
         assertThrows(NoSuchElementException.class, () -> iterator.next());
         assertFalse(iterator.hasNext());
     }
 
     @Test
     public void MergeWithEmptyValueTest() {
-        List<DataPoint<Integer, String>> x = List.of();
-        var expected = new Object[] {};
-        var actual = Series.merge(x).stream().toArray();
+        final List<DataPoint<Integer, String>> x = List.of();
+        final var expected = new Object[] {};
+        final var actual = Series.merge(x).stream().toArray();
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void MergeWithSameValueTest() {
-        List<DataPoint<Integer, Optional<Integer>>> x = List.of(
+        final List<DataPoint<Integer, Optional<Integer>>> x = List.of(
                 Series.datapoint(1, Optional.of(10)),
                 Series.datapoint(5, Optional.of(10)),
                 Series.datapoint(10, Optional.empty()));
 
-        var expected = List.of(Series.datapoint(1, Optional.of(10)), Series.datapoint(10, Optional.empty())).toArray();
+        final var expected = List.of(Series.datapoint(1, Optional.of(10)), Series.datapoint(10, Optional.empty()))
+                .toArray();
 
-        var actual = Series.merge(x).stream().toArray();
+        final var actual = Series.merge(x).stream().toArray();
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void MergeWithDifferentValueTest() {
-        List<DataPoint<Integer, Optional<Integer>>> x = List.of(
+        final List<DataPoint<Integer, Optional<Integer>>> x = List.of(
                 Series.datapoint(1, Optional.of(10)),
                 Series.datapoint(5, Optional.of(100)),
                 Series.datapoint(10, Optional.empty()));
 
-        var expected = List.of(
+        final var expected = List.of(
                 Series.datapoint(1, Optional.of(10)),
                 Series.datapoint(5, Optional.of(100)),
                 Series.datapoint(10, Optional.empty())).toArray();
 
-        var actual = Series.merge(x).stream().toArray();
+        final var actual = Series.merge(x).stream().toArray();
         assertArrayEquals(expected, actual);
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/UnionTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/UnionTest.java
@@ -7,282 +7,282 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class UnionTest {
-        record Tuple<T1, T2>(T1 fst, T2 snd) {
+    record Tuple<T1, T2>(T1 fst, T2 snd) {
+    }
+
+    private static void test(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
+            final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right) {
+        test_ex(expected, left, right, true);
+    }
+
+    private static void test_ex(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
+            final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right,
+            final Boolean canMirror) {
+        {
+            final var union = Series.union(left, right, (x -> x));
+            final var actual = union.stream().toArray();
+            assertArrayEquals(expected.toArray(), actual);
         }
+        if (canMirror) {
+            final var union = Series.union(right, left, (x -> x));
+            final var actual = union.stream().toArray();
 
-        private static void test(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
-                        final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right) {
-                test_ex(expected, left, right, true);
+            final var expectedArray = expected.stream().map(x -> switch (x.data()) {
+                case UnionResult.LeftOnly<Integer, Integer> leftOnly ->
+                    Series.datapoint(x.point(), UnionResult.rightOnly(leftOnly.left()));
+                case UnionResult.RightOnly<Integer, Integer> rightOnly ->
+                    Series.datapoint(x.point(), UnionResult.leftOnly(rightOnly.right()));
+                case UnionResult.Both<Integer, Integer> both ->
+                    Series.datapoint(x.point(), UnionResult.both(both.right(), both.left()));
+            }).toArray();
+            assertArrayEquals(expectedArray, actual);
         }
+    }
 
-        private static void test_ex(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
-                        final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right,
-                        final Boolean canMirror) {
-                {
-                        final var union = Series.union(left, right, (x -> x));
-                        final var actual = union.stream().toArray();
-                        assertArrayEquals(expected.toArray(), actual);
-                }
-                if (canMirror) {
-                        final var union = Series.union(right, left, (x -> x));
-                        final var actual = union.stream().toArray();
+    @Test
+    public void emptyTest() {
+        test(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    }
 
-                        final var expectedArray = expected.stream().map(x -> switch (x.data()) {
-                                case UnionResult.LeftOnly<Integer, Integer> leftOnly ->
-                                        Series.datapoint(x.point(), UnionResult.rightOnly(leftOnly.left()));
-                                case UnionResult.RightOnly<Integer, Integer> rightOnly ->
-                                        Series.datapoint(x.point(), UnionResult.leftOnly(rightOnly.right()));
-                                case UnionResult.Both<Integer, Integer> both ->
-                                        Series.datapoint(x.point(), UnionResult.both(both.right(), both.left()));
-                        }).toArray();
-                        assertArrayEquals(expectedArray, actual);
-                }
-        }
+    @Test
+    public void singleEmptyTest() {
+        final List<DataPoint<Integer, Integer>> left = List.of(Series.datapoint(1, 100));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List
+                .of(Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)));
 
-        @Test
-        public void emptyTest() {
-                test(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        }
+        test(expected, left, Collections.emptyList());
+    }
 
-        @Test
-        public void singleEmptyTest() {
-                final List<DataPoint<Integer, Integer>> left = List.of(Series.datapoint(1, 100));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List
-                                .of(Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)));
+    @Test
+    public void singlesEmptyTest() {
+        final List<DataPoint<Integer, Integer>> left = List.of(
+                Series.datapoint(1, 100),
+                Series.datapoint(3, 100),
+                Series.datapoint(4, 100));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)),
+                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(100)),
+                Series.datapoint(4, new UnionResult.LeftOnly<Integer, Integer>(100)));
 
-                test(expected, left, Collections.emptyList());
-        }
+        test(expected, left, Collections.emptyList());
+    }
 
-        @Test
-        public void singlesEmptyTest() {
-                final List<DataPoint<Integer, Integer>> left = List.of(
-                                Series.datapoint(1, 100),
-                                Series.datapoint(3, 100),
-                                Series.datapoint(4, 100));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)),
-                                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(100)),
-                                Series.datapoint(4, new UnionResult.LeftOnly<Integer, Integer>(100)));
+    @Test
+    public void singleSingleTest() {
+        final List<DataPoint<Integer, Integer>> left = List.of(
+                Series.datapoint(2, 120));
+        final List<DataPoint<Integer, Integer>> right = List.of(
+                Series.datapoint(1, 100));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
+                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)));
 
-                test(expected, left, Collections.emptyList());
-        }
+        test(expected, left, right);
+    }
 
-        @Test
-        public void singleSingleTest() {
-                final List<DataPoint<Integer, Integer>> left = List.of(
-                                Series.datapoint(2, 120));
-                final List<DataPoint<Integer, Integer>> right = List.of(
-                                Series.datapoint(1, 100));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
-                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)));
+    @Test
+    public void singleSingleFullOverlapTest() {
+        final List<DataPoint<Integer, Integer>> left = List.of(
+                Series.datapoint(1, 120));
+        final List<DataPoint<Integer, Integer>> right = List.of(
+                Series.datapoint(1, 100));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(120, 100)));
 
-                test(expected, left, right);
-        }
+        test(expected, left, right);
+    }
 
-        @Test
-        public void singleSingleFullOverlapTest() {
-                final List<DataPoint<Integer, Integer>> left = List.of(
-                                Series.datapoint(1, 120));
-                final List<DataPoint<Integer, Integer>> right = List.of(
-                                Series.datapoint(1, 100));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(120, 100)));
+    @Test
+    public void singlePairTest() {
+        final var left = List.of(Series.datapoint(10, 130));
+        final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
+                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)));
+        test(expected, left, right);
+    }
 
-                test(expected, left, right);
-        }
+    @Test
+    public void singlePairTest2() {
+        final var left = List.of(Series.datapoint(2, 120));
+        final var right = List.of(Series.datapoint(1, 100), Series.datapoint(3, 150));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
+                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 150)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void singlePairTest() {
-                final var left = List.of(Series.datapoint(10, 130));
-                final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
-                                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)));
-                test(expected, left, right);
-        }
+    @Test
+    public void singleMultiple3Test() {
+        final var left = List.of(Series.datapoint(1, 120));
+        final var right = List.of(Series.datapoint(2, 100), Series.datapoint(5, 150));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(120)),
+                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
+                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 150)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void singlePairTest2() {
-                final var left = List.of(Series.datapoint(2, 120));
-                final var right = List.of(Series.datapoint(1, 100), Series.datapoint(3, 150));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
-                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 150)));
-                test(expected, left, right);
-        }
+    @Test
+    public void partialIntersectionTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95));
+        final var right = List.of(Series.datapoint(2, 120), Series.datapoint(10, 95));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(130, 120)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void singleMultiple3Test() {
-                final var left = List.of(Series.datapoint(1, 120));
-                final var right = List.of(Series.datapoint(2, 100), Series.datapoint(5, 150));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(120)),
-                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
-                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 150)));
-                test(expected, left, right);
-        }
+    @Test
+    public void segmentedFullIntersectionTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95));
+        final var right = List.of(Series.datapoint(3, 120), Series.datapoint(10, 95));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void partialIntersectionTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95));
-                final var right = List.of(Series.datapoint(2, 120), Series.datapoint(10, 95));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(130, 120)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
-                test(expected, left, right);
-        }
+    @Test
+    public void pairPairTest() {
+        final var left = List.of(Series.datapoint(10, 130), Series.datapoint(12, 140));
+        final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
+                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)),
+                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(140, 200)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void segmentedFullIntersectionTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95));
-                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(10, 95));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
-                test(expected, left, right);
-        }
+    @Test
+    public void multipleFirstTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(2, 140),
+                Series.datapoint(5, 150),
+                Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(30, 120));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(2, new UnionResult.LeftOnly<Integer, Integer>(140)),
+                Series.datapoint(5, new UnionResult.LeftOnly<Integer, Integer>(150)),
+                Series.datapoint(20, new UnionResult.LeftOnly<Integer, Integer>(160)),
+                Series.datapoint(30, new UnionResult.Both<Integer, Integer>(160, 120)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void pairPairTest() {
-                final var left = List.of(Series.datapoint(10, 130), Series.datapoint(12, 140));
-                final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
-                                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)),
-                                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(140, 200)));
-                test(expected, left, right);
-        }
+    @Test
+    public void multipleIntersectionTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
+                Series.datapoint(6, 100),
+                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                Series.datapoint(19, 180));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
+                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
+                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
+                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
+                Series.datapoint(19, new UnionResult.Both<Integer, Integer>(130, 180)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void multipleFirstTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(2, 140),
-                                Series.datapoint(5, 150),
-                                Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(30, 120));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(2, new UnionResult.LeftOnly<Integer, Integer>(140)),
-                                Series.datapoint(5, new UnionResult.LeftOnly<Integer, Integer>(150)),
-                                Series.datapoint(20, new UnionResult.LeftOnly<Integer, Integer>(160)),
-                                Series.datapoint(30, new UnionResult.Both<Integer, Integer>(160, 120)));
-                test(expected, left, right);
-        }
+    @Test
+    public void multipleIntersectionsOverlapTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
+                Series.datapoint(6, 100),
+                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                Series.datapoint(20, 180));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
+                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
+                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
+                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void multipleIntersectionTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
-                                Series.datapoint(6, 100),
-                                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                                Series.datapoint(19, 180));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
-                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
-                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
-                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
-                                Series.datapoint(19, new UnionResult.Both<Integer, Integer>(130, 180)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-                test(expected, left, right);
-        }
+    @Test
+    public void multipleIntersectionsOverlapsTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(3, 105), Series.datapoint(5, 110),
+                Series.datapoint(6, 100),
+                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                Series.datapoint(20, 180));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 105)),
+                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 110)),
+                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(120, 100)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 90)),
+                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 190)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void multipleIntersectionsOverlapTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
-                                Series.datapoint(6, 100),
-                                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                                Series.datapoint(20, 180));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
-                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
-                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
-                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-                test(expected, left, right);
-        }
+    @Test
+    public void multipleNoIntersectionTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(12, 105), Series.datapoint(15, 110));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(120)),
+                Series.datapoint(10, new UnionResult.LeftOnly<Integer, Integer>(95)),
+                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(95, 105)),
+                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 110)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 110)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void multipleIntersectionsOverlapsTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(3, 105), Series.datapoint(5, 110),
-                                Series.datapoint(6, 100),
-                                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                                Series.datapoint(20, 180));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 105)),
-                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 110)),
-                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(120, 100)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 90)),
-                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 190)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-                test(expected, left, right);
-        }
+    @Test
+    public void fullIntersectionTest() {
+        final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
+        test(expected, left, right);
+    }
 
-        @Test
-        public void multipleNoIntersectionTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(12, 105), Series.datapoint(15, 110));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(120)),
-                                Series.datapoint(10, new UnionResult.LeftOnly<Integer, Integer>(95)),
-                                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(95, 105)),
-                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 110)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 110)));
-                test(expected, left, right);
-        }
-
-        @Test
-        public void fullIntersectionTest() {
-                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
-                test(expected, left, right);
-        }
-
-        @Test
-        public void fullIntersection2Test() {
-                final var left = List.of(Series.datapoint(-15, 130), Series.datapoint(-1, 130),
-                                Series.datapoint(1, 130),
-                                Series.datapoint(3, 120), Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                                Series.datapoint(10, 95),
-                                Series.datapoint(20, 160));
-                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                                Series.datapoint(-15, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(-1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
-                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
-                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
-                test(expected, left, right);
-        }
+    @Test
+    public void fullIntersection2Test() {
+        final var left = List.of(Series.datapoint(-15, 130), Series.datapoint(-1, 130),
+                Series.datapoint(1, 130),
+                Series.datapoint(3, 120), Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                Series.datapoint(10, 95),
+                Series.datapoint(20, 160));
+        final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                Series.datapoint(-15, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(-1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
+                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
+                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
+        test(expected, left, right);
+    }
 
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/UnionTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/UnionTest.java
@@ -7,282 +7,282 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class UnionTest {
-    record Tuple<T1, T2>(T1 fst, T2 snd) {
-    }
-
-    private static void test(List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
-            List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right) {
-        test_ex(expected, left, right, true);
-    }
-
-    private static void test_ex(List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
-            List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right,
-            Boolean canMirror) {
-        {
-            var union = Series.union(left, right, (x -> x));
-            var actual = union.stream().toArray();
-            assertArrayEquals(expected.toArray(), actual);
+        record Tuple<T1, T2>(T1 fst, T2 snd) {
         }
-        if (canMirror) {
-            var union = Series.union(right, left, (x -> x));
-            var actual = union.stream().toArray();
 
-            var expectedArray = expected.stream().map(x -> switch (x.data()) {
-                case UnionResult.LeftOnly<Integer, Integer> leftOnly ->
-                    Series.datapoint(x.point(), UnionResult.rightOnly(leftOnly.left()));
-                case UnionResult.RightOnly<Integer, Integer> rightOnly ->
-                    Series.datapoint(x.point(), UnionResult.leftOnly(rightOnly.right()));
-                case UnionResult.Both<Integer, Integer> both ->
-                    Series.datapoint(x.point(), UnionResult.both(both.right(), both.left()));
-            }).toArray();
-            assertArrayEquals(expectedArray, actual);
+        private static void test(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
+                        final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right) {
+                test_ex(expected, left, right, true);
         }
-    }
 
-    @Test
-    public void emptyTest() {
-        test(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    }
+        private static void test_ex(final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected,
+                        final List<DataPoint<Integer, Integer>> left, List<DataPoint<Integer, Integer>> right,
+                        final Boolean canMirror) {
+                {
+                        final var union = Series.union(left, right, (x -> x));
+                        final var actual = union.stream().toArray();
+                        assertArrayEquals(expected.toArray(), actual);
+                }
+                if (canMirror) {
+                        final var union = Series.union(right, left, (x -> x));
+                        final var actual = union.stream().toArray();
 
-    @Test
-    public void singleEmptyTest() {
-        List<DataPoint<Integer, Integer>> left = List.of(Series.datapoint(1, 100));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List
-                .of(Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)));
+                        final var expectedArray = expected.stream().map(x -> switch (x.data()) {
+                                case UnionResult.LeftOnly<Integer, Integer> leftOnly ->
+                                        Series.datapoint(x.point(), UnionResult.rightOnly(leftOnly.left()));
+                                case UnionResult.RightOnly<Integer, Integer> rightOnly ->
+                                        Series.datapoint(x.point(), UnionResult.leftOnly(rightOnly.right()));
+                                case UnionResult.Both<Integer, Integer> both ->
+                                        Series.datapoint(x.point(), UnionResult.both(both.right(), both.left()));
+                        }).toArray();
+                        assertArrayEquals(expectedArray, actual);
+                }
+        }
 
-        test(expected, left, Collections.emptyList());
-    }
+        @Test
+        public void emptyTest() {
+                test(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        }
 
-    @Test
-    public void singlesEmptyTest() {
-        List<DataPoint<Integer, Integer>> left = List.of(
-                Series.datapoint(1, 100),
-                Series.datapoint(3, 100),
-                Series.datapoint(4, 100));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)),
-                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(100)),
-                Series.datapoint(4, new UnionResult.LeftOnly<Integer, Integer>(100)));
+        @Test
+        public void singleEmptyTest() {
+                final List<DataPoint<Integer, Integer>> left = List.of(Series.datapoint(1, 100));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List
+                                .of(Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)));
 
-        test(expected, left, Collections.emptyList());
-    }
+                test(expected, left, Collections.emptyList());
+        }
 
-    @Test
-    public void singleSingleTest() {
-        List<DataPoint<Integer, Integer>> left = List.of(
-                Series.datapoint(2, 120));
-        List<DataPoint<Integer, Integer>> right = List.of(
-                Series.datapoint(1, 100));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
-                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)));
+        @Test
+        public void singlesEmptyTest() {
+                final List<DataPoint<Integer, Integer>> left = List.of(
+                                Series.datapoint(1, 100),
+                                Series.datapoint(3, 100),
+                                Series.datapoint(4, 100));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(100)),
+                                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(100)),
+                                Series.datapoint(4, new UnionResult.LeftOnly<Integer, Integer>(100)));
 
-        test(expected, left, right);
-    }
+                test(expected, left, Collections.emptyList());
+        }
 
-    @Test
-    public void singleSingleFullOverlapTest() {
-        List<DataPoint<Integer, Integer>> left = List.of(
-                Series.datapoint(1, 120));
-        List<DataPoint<Integer, Integer>> right = List.of(
-                Series.datapoint(1, 100));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(120, 100)));
+        @Test
+        public void singleSingleTest() {
+                final List<DataPoint<Integer, Integer>> left = List.of(
+                                Series.datapoint(2, 120));
+                final List<DataPoint<Integer, Integer>> right = List.of(
+                                Series.datapoint(1, 100));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
+                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)));
 
-        test(expected, left, right);
-    }
+                test(expected, left, right);
+        }
 
-    @Test
-    public void singlePairTest() {
-        var left = List.of(Series.datapoint(10, 130));
-        var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
-                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)));
-        test(expected, left, right);
-    }
+        @Test
+        public void singleSingleFullOverlapTest() {
+                final List<DataPoint<Integer, Integer>> left = List.of(
+                                Series.datapoint(1, 120));
+                final List<DataPoint<Integer, Integer>> right = List.of(
+                                Series.datapoint(1, 100));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(120, 100)));
 
-    @Test
-    public void singlePairTest2() {
-        var left = List.of(Series.datapoint(2, 120));
-        var right = List.of(Series.datapoint(1, 100), Series.datapoint(3, 150));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
-                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 150)));
-        test(expected, left, right);
-    }
+                test(expected, left, right);
+        }
 
-    @Test
-    public void singleMultiple3Test() {
-        var left = List.of(Series.datapoint(1, 120));
-        var right = List.of(Series.datapoint(2, 100), Series.datapoint(5, 150));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(120)),
-                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
-                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 150)));
-        test(expected, left, right);
-    }
+        @Test
+        public void singlePairTest() {
+                final var left = List.of(Series.datapoint(10, 130));
+                final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
+                                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void partialIntersectionTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95));
-        var right = List.of(Series.datapoint(2, 120), Series.datapoint(10, 95));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(130, 120)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
-        test(expected, left, right);
-    }
+        @Test
+        public void singlePairTest2() {
+                final var left = List.of(Series.datapoint(2, 120));
+                final var right = List.of(Series.datapoint(1, 100), Series.datapoint(3, 150));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(100)),
+                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 150)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void segmentedFullIntersectionTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95));
-        var right = List.of(Series.datapoint(3, 120), Series.datapoint(10, 95));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
-        test(expected, left, right);
-    }
+        @Test
+        public void singleMultiple3Test() {
+                final var left = List.of(Series.datapoint(1, 120));
+                final var right = List.of(Series.datapoint(2, 100), Series.datapoint(5, 150));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(120)),
+                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(120, 100)),
+                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 150)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void pairPairTest() {
-        var left = List.of(Series.datapoint(10, 130), Series.datapoint(12, 140));
-        var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
-                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)),
-                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(140, 200)));
-        test(expected, left, right);
-    }
+        @Test
+        public void partialIntersectionTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95));
+                final var right = List.of(Series.datapoint(2, 120), Series.datapoint(10, 95));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(2, new UnionResult.Both<Integer, Integer>(130, 120)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void multipleFirstTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(2, 140),
-                Series.datapoint(5, 150),
-                Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(30, 120));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(2, new UnionResult.LeftOnly<Integer, Integer>(140)),
-                Series.datapoint(5, new UnionResult.LeftOnly<Integer, Integer>(150)),
-                Series.datapoint(20, new UnionResult.LeftOnly<Integer, Integer>(160)),
-                Series.datapoint(30, new UnionResult.Both<Integer, Integer>(160, 120)));
-        test(expected, left, right);
-    }
+        @Test
+        public void segmentedFullIntersectionTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95));
+                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(10, 95));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void multipleIntersectionTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
-                Series.datapoint(6, 100),
-                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                Series.datapoint(19, 180));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
-                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
-                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
-                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
-                Series.datapoint(19, new UnionResult.Both<Integer, Integer>(130, 180)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-        test(expected, left, right);
-    }
+        @Test
+        public void pairPairTest() {
+                final var left = List.of(Series.datapoint(10, 130), Series.datapoint(12, 140));
+                final var right = List.of(Series.datapoint(1, 120), Series.datapoint(5, 200));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.RightOnly<Integer, Integer>(120)),
+                                Series.datapoint(5, new UnionResult.RightOnly<Integer, Integer>(200)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 200)),
+                                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(140, 200)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void multipleIntersectionsOverlapTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
-                Series.datapoint(6, 100),
-                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                Series.datapoint(20, 180));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
-                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
-                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
-                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-        test(expected, left, right);
-    }
+        @Test
+        public void multipleFirstTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(2, 140),
+                                Series.datapoint(5, 150),
+                                Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(30, 120));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(2, new UnionResult.LeftOnly<Integer, Integer>(140)),
+                                Series.datapoint(5, new UnionResult.LeftOnly<Integer, Integer>(150)),
+                                Series.datapoint(20, new UnionResult.LeftOnly<Integer, Integer>(160)),
+                                Series.datapoint(30, new UnionResult.Both<Integer, Integer>(160, 120)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void multipleIntersectionsOverlapsTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(3, 105), Series.datapoint(5, 110),
-                Series.datapoint(6, 100),
-                Series.datapoint(10, 90), Series.datapoint(15, 190),
-                Series.datapoint(20, 180));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 105)),
-                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 110)),
-                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(120, 100)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 90)),
-                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 190)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
-        test(expected, left, right);
-    }
+        @Test
+        public void multipleIntersectionTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
+                                Series.datapoint(6, 100),
+                                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                                Series.datapoint(19, 180));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
+                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
+                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
+                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
+                                Series.datapoint(19, new UnionResult.Both<Integer, Integer>(130, 180)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void multipleNoIntersectionTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(12, 105), Series.datapoint(15, 110));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(120)),
-                Series.datapoint(10, new UnionResult.LeftOnly<Integer, Integer>(95)),
-                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(95, 105)),
-                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 110)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 110)));
-        test(expected, left, right);
-    }
+        @Test
+        public void multipleIntersectionsOverlapTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(3, 120), Series.datapoint(5, 110),
+                                Series.datapoint(6, 100),
+                                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                                Series.datapoint(20, 180));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(130, 120)),
+                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(130, 110)),
+                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(130, 100)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(130, 90)),
+                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(130, 190)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void fullIntersectionTest() {
-        var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
-        test(expected, left, right);
-    }
+        @Test
+        public void multipleIntersectionsOverlapsTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(3, 105), Series.datapoint(5, 110),
+                                Series.datapoint(6, 100),
+                                Series.datapoint(10, 90), Series.datapoint(15, 190),
+                                Series.datapoint(20, 180));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 105)),
+                                Series.datapoint(5, new UnionResult.Both<Integer, Integer>(120, 110)),
+                                Series.datapoint(6, new UnionResult.Both<Integer, Integer>(120, 100)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 90)),
+                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 190)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 180)));
+                test(expected, left, right);
+        }
 
-    @Test
-    public void fullIntersection2Test() {
-        var left = List.of(Series.datapoint(-15, 130), Series.datapoint(-1, 130),
-                Series.datapoint(1, 130),
-                Series.datapoint(3, 120), Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
-                Series.datapoint(10, 95),
-                Series.datapoint(20, 160));
-        List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
-                Series.datapoint(-15, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(-1, new UnionResult.LeftOnly<Integer, Integer>(130)),
-                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
-                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
-                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
-                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
-        test(expected, left, right);
-    }
+        @Test
+        public void multipleNoIntersectionTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(12, 105), Series.datapoint(15, 110));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(3, new UnionResult.LeftOnly<Integer, Integer>(120)),
+                                Series.datapoint(10, new UnionResult.LeftOnly<Integer, Integer>(95)),
+                                Series.datapoint(12, new UnionResult.Both<Integer, Integer>(95, 105)),
+                                Series.datapoint(15, new UnionResult.Both<Integer, Integer>(95, 110)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 110)));
+                test(expected, left, right);
+        }
+
+        @Test
+        public void fullIntersectionTest() {
+                final var left = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
+                test(expected, left, right);
+        }
+
+        @Test
+        public void fullIntersection2Test() {
+                final var left = List.of(Series.datapoint(-15, 130), Series.datapoint(-1, 130),
+                                Series.datapoint(1, 130),
+                                Series.datapoint(3, 120), Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final var right = List.of(Series.datapoint(1, 130), Series.datapoint(3, 120),
+                                Series.datapoint(10, 95),
+                                Series.datapoint(20, 160));
+                final List<DataPoint<Integer, UnionResult<Integer, Integer>>> expected = List.of(
+                                Series.datapoint(-15, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(-1, new UnionResult.LeftOnly<Integer, Integer>(130)),
+                                Series.datapoint(1, new UnionResult.Both<Integer, Integer>(130, 130)),
+                                Series.datapoint(3, new UnionResult.Both<Integer, Integer>(120, 120)),
+                                Series.datapoint(10, new UnionResult.Both<Integer, Integer>(95, 95)),
+                                Series.datapoint(20, new UnionResult.Both<Integer, Integer>(160, 160)));
+                test(expected, left, right);
+        }
 
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
@@ -1,0 +1,192 @@
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.DataPoint;
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class CrdtTest {
+    @Test
+    public void resolveConflictsTest() {
+        final var actual = Series.union(List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10))),
+                List.of(
+                        datapoint(2, date(2023, 1, 4), 100),
+                        end(date(2023, 1, 5)),
+                        datapoint(2, date(2023, 1, 7), 110),
+                        end(date(2023, 1, 9))),
+                CrdtTest::resolveConflicts);
+
+        final var expected = List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                datapoint(2, date(2023, 1, 4), 100),
+                datapoint(1, date(2023, 1, 5), 50),
+                datapoint(2, date(2023, 1, 7), 110),
+                datapoint(1, date(2023, 1, 9), 50),
+                end(date(2023, 1, 10)));
+
+        assertArrayEquals(expected.toArray(), actual.stream().toArray());
+    }
+
+    @Test
+    public void noConflictTest() {
+        final var actual = Series.union(List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10))),
+                List.of(
+                        datapoint(2, date(2023, 1, 15), 100),
+                        end(date(2023, 1, 20))
+
+                ), CrdtTest::resolveConflicts);
+
+        final var expected = List.of(
+                datapoint(1, date(2023, 1, 3), 50),
+                end(date(2023, 1, 10)),
+                datapoint(2, date(2023, 1, 15), 100),
+                end(date(2023, 1, 20)));
+        assertArrayEquals(expected.toArray(), actual.stream().toArray());
+    }
+
+    /**
+     * Optional from java.util does not provide any Comparable<Optional<T>>
+     * implementation like other languages (rust with traits).
+     * 
+     * This Algebraic data type provides this implementation of a conventional
+     * option.
+     */
+    private static sealed interface Option<T extends Comparable<T>> extends Comparable<Option<T>>
+            permits Option.None, Option.Some {
+        default int compareTo(final Option<T> o) {
+            switch (this) {
+                case final None<T> n1 -> {
+                    switch (o) {
+                        case final None<T> n2 -> {
+                            return 0;
+                        }
+                        case final Some<T> s -> {
+                            return -1;
+                        }
+                    }
+                }
+                case final Some<T> s1 -> {
+                    switch (o) {
+                        case None<T> n -> {
+                            return 1;
+                        }
+                        case Some<T> s2 -> {
+                            return s1.value.compareTo(s2.value);
+                        }
+                    }
+                }
+            }
+        }
+
+        static record None<T extends Comparable<T>>() implements Option<T> {
+        }
+
+        static record Some<T extends Comparable<T>>(T value) implements Option<T> {
+
+        }
+
+        private static <T extends Comparable<T>> Option<T> none() {
+            return new None<>();
+        }
+
+        private static <T extends Comparable<T>> Option<T> some(final T value) {
+            return new Some<>(value);
+        }
+    }
+
+    private static record VersionedValue<V extends Comparable<V>, T extends Comparable<T>>(V version, T value)
+            implements Comparable<VersionedValue<V, T>> {
+        @Override
+        public int compareTo(final VersionedValue<V, T> o) {
+            var vc = this.version.compareTo(o.version);
+
+            if (vc < 0) {
+                return -1;
+            }
+
+            if (vc > 0) {
+                return 1;
+            }
+
+            return this.value.compareTo(o.value);
+        }
+    }
+
+    private static record Date(Integer year, Integer month, Integer day) implements Comparable<Date> {
+
+        @Override
+        public int compareTo(final Date o) {
+            if (this.year > o.year) {
+                return 1;
+            }
+
+            if (this.year < o.year) {
+                return -1;
+            }
+
+            if (this.month > o.month) {
+                return 1;
+            }
+
+            if (this.month < o.month) {
+                return -1;
+            }
+
+            if (this.day > o.day) {
+                return 1;
+            }
+
+            if (this.day < o.day) {
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+
+    private static final Date date(final Integer year, final Integer month, final Integer day) {
+        return new Date(year, month, day);
+    }
+
+    private static final <T extends Comparable<T>> DataPoint<Date, Option<VersionedValue<Integer, T>>> datapoint(
+            final Integer timestampMicros, final Date date, final T data) {
+        return Series.datapoint(date, Option.some(new VersionedValue<>(timestampMicros, data)));
+    }
+
+    /// Interval can be encoded by using 2 Datapoints with a [`None`] last datapoint
+    /// value to mark the end of each interval
+    private static final <T extends Comparable<T>> DataPoint<Date, Option<VersionedValue<Integer, T>>> end(
+            final Date date) {
+        return Series.datapoint(date, Option.none());
+    }
+
+    /**
+     * Solves conflict by taking always the maximum version
+     */
+    private static final <T extends Comparable<T>> T resolveConflicts(final UnionResult<T, T> unionResult) {
+        switch (unionResult) {
+            case final UnionResult.LeftOnly<T, T> l -> {
+                return l.left();
+            }
+            case final UnionResult.RightOnly<T, T> r -> {
+                return r.right();
+            }
+            case final UnionResult.Both<T, T> b -> {
+                if (b.right().compareTo(b.left()) > 0) {
+                    return b.right();
+                }
+
+                return b.left();
+            }
+        }
+    }
+}

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
@@ -84,10 +84,10 @@ public class CrdtTest {
                         }
                     }
                 }
-                // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
-                // java 20 at least)
-                throw new UnsupportedOperationException();
             }
+            // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+            // java 20 at least)
+            throw new UnsupportedOperationException();
         }
 
         static record None<T extends Comparable<T>>() implements Option<T> {
@@ -190,9 +190,9 @@ public class CrdtTest {
 
                 return b.left();
             }
-            // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
-            // java 20 at least)
-            throw new UnsupportedOperationException();
         }
+        // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+        // java 20 at least)
+        throw new UnsupportedOperationException();
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/CrdtTest.java
@@ -84,6 +84,9 @@ public class CrdtTest {
                         }
                     }
                 }
+                // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+                // java 20 at least)
+                throw new UnsupportedOperationException();
             }
         }
 
@@ -187,6 +190,9 @@ public class CrdtTest {
 
                 return b.left();
             }
+            // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+            // java 20 at least)
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
@@ -40,6 +40,9 @@ public class IntersectionTest {
             case UnionResult.Both<L, R> both -> {
                 return Optional.of(new Tuple<L, R>(both.left(), both.right()));
             }
+            // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+            // java 20 at least)
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
@@ -1,0 +1,45 @@
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class IntersectionTest {
+    @Test
+    public void intersection() {
+        final var s1 = List.of(Series.datapoint(3, 50));
+        final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));
+
+        final var actual = Series.union(s1, s2, IntersectionTest::toTuple).stream().filter(x -> x.data().isPresent())
+                .map(x -> Series.datapoint(x.point(), x.data().get())).toArray();
+
+        final var expected = List.of(
+                Series.datapoint(4, new Tuple<>(50, 100)),
+                Series.datapoint(7, new Tuple<>(50, 110))).toArray();
+
+        assertArrayEquals(expected, actual);
+    }
+
+    private static record Tuple<L, R>(L fst, R snd) {
+    }
+
+    private static <L, R> Optional<Tuple<L, R>> toTuple(UnionResult<L, R> unionResult) {
+        switch (unionResult) {
+            case UnionResult.LeftOnly<L, R> x -> {
+                return Optional.empty();
+            }
+            case UnionResult.RightOnly<L, R> x -> {
+                return Optional.empty();
+            }
+
+            case UnionResult.Both<L, R> both -> {
+                return Optional.of(new Tuple<L, R>(both.left(), both.right()));
+            }
+        }
+    }
+}

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/IntersectionTest.java
@@ -40,9 +40,9 @@ public class IntersectionTest {
             case UnionResult.Both<L, R> both -> {
                 return Optional.of(new Tuple<L, R>(both.left(), both.right()));
             }
-            // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
-            // java 20 at least)
-            throw new UnsupportedOperationException();
         }
+        // FIXME : remove this when https://openjdk.org/jeps/433 will be ready (> 17,
+        // java 20 at least)
+        throw new UnsupportedOperationException();
     }
 }

--- a/java/src/test/java/io/github/cboudereau/dataseries/snippets/SimpleTest.java
+++ b/java/src/test/java/io/github/cboudereau/dataseries/snippets/SimpleTest.java
@@ -1,0 +1,26 @@
+package io.github.cboudereau.dataseries.snippets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import io.github.cboudereau.dataseries.Series;
+import io.github.cboudereau.dataseries.UnionResult;
+
+public class SimpleTest {
+    @Test
+    public void simple() {
+        final var s1 = List.of(Series.datapoint(3, 50));
+        final var s2 = List.of(Series.datapoint(4, 100), Series.datapoint(7, 110));
+
+        final var actual = Series.union(s1, s2, x -> x).stream().toArray();
+
+        final var expected = List.of(
+                Series.datapoint(3, UnionResult.leftOnly(50)),
+                Series.datapoint(4, UnionResult.both(50, 100)),
+                Series.datapoint(7, UnionResult.both(50, 110))).toArray();
+
+        assertArrayEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This PR is a compatible version of adding snippets with legacy javadoc code.

- [x] add javadoc badges
- [x] add side notes about using rust examples equivalent : java snippets : https://docs.oracle.com/en/java/javase/18/code-snippet/index.html#external-snippets
- add snippets as unit tests 
  - [x] simple
  - [x] intersection
  - [x] crdt
- [x] update README
- [x] clean (mostly add final everywhere) and fix type inference issue with datapoint helper method 
- [x] add snippets as code in Series.java javadoc
